### PR TITLE
fix for crashing on unsupported attribute

### DIFF
--- a/src/site-packages/openbmp/mrt2bmp/MrtParser.py
+++ b/src/site-packages/openbmp/mrt2bmp/MrtParser.py
@@ -462,7 +462,7 @@ class MrtParser():
                     raw_bgp_attributes.append(buf[start:end])
             else:
                 # Attribute not supported.
-                raise MrtFileException("Unsupported attribute type: {0}.".format(bgp_path_attribute['type'])
+                print "Unsupported attribute type: {0}.".format(bgp_path_attribute['type'])
  
             bgp_attribute_list.append(bgp_path_attribute)
 

--- a/src/site-packages/openbmp/mrt2bmp/MrtParser.py
+++ b/src/site-packages/openbmp/mrt2bmp/MrtParser.py
@@ -422,44 +422,48 @@ class MrtParser():
                 Only NEXT_HOP or MP_REACH_NLRI exists, both of them cannot co-exist in path attributes.
             """
             # Parse out NEXT_HOP attribute
-            if BGP_ATTRIBUTES[bgp_path_attribute['type']] == 'NEXT_HOP':
-
-                if ADDRESS_FAMILY[address_family] == "IPv4":
-                    # Address family is IPv4.
-                    raw_next_hop = buf[p:p + 4]
-                    raw_next_hop_length = struct.pack("!B", 4)
-                    p += 4
-
-                elif ADDRESS_FAMILY[address_family] == "IPv6":
-                    # Address family is IPv6.
-                    raw_next_hop = buf[p:p + 16]
-                    raw_next_hop_length = struct.pack("!B", 16)
-                    p += 16
-
-                # Add MP_REACH_NLRI attribute to raw attribute value.
-                raw_mp_reach_nlri['value'] = self.crateMpReachNlriAttributeRaw(address_family, safi, (raw_next_hop_length + raw_next_hop), b"")
-
-            # Parse out MP_REACH attribute
-            elif BGP_ATTRIBUTES[bgp_path_attribute['type']] == 'MP_REACH_NLRI':
-
-                """
-                There is one exception to the encoding of BGP attributes for the BGP
-                MP_REACH_NLRI attribute (BGP Type Code 14) [RFC4760].  Since the AFI,
-                SAFI, and NLRI information is already encoded in the RIB Entry Header
-                or RIB_GENERIC Entry Header, only the Next Hop Address Length and
-                Next Hop Address fields are included.
-                """
-
-                raw_next_hop_attr = buf[p:p+bgp_path_attribute['len']]
-
-                p += bgp_path_attribute['len']
-                raw_mp_reach_nlri['value'] = self.crateMpReachNlriAttributeRaw(address_family, safi, raw_next_hop_attr, b"")
-
-            # No parsing for other attributes.
+            if bgp_path_attribute['type'] in BGP_ATTRIBUTES:
+                if BGP_ATTRIBUTES[bgp_path_attribute['type']] == 'NEXT_HOP':
+    
+                    if ADDRESS_FAMILY[address_family] == "IPv4":
+                        # Address family is IPv4.
+                        raw_next_hop = buf[p:p + 4]
+                        raw_next_hop_length = struct.pack("!B", 4)
+                        p += 4
+    
+                    elif ADDRESS_FAMILY[address_family] == "IPv6":
+                        # Address family is IPv6.
+                        raw_next_hop = buf[p:p + 16]
+                        raw_next_hop_length = struct.pack("!B", 16)
+                        p += 16
+    
+                    # Add MP_REACH_NLRI attribute to raw attribute value.
+                    raw_mp_reach_nlri['value'] = self.crateMpReachNlriAttributeRaw(address_family, safi, (raw_next_hop_length + raw_next_hop), b"")
+    
+                # Parse out MP_REACH attribute
+                elif BGP_ATTRIBUTES[bgp_path_attribute['type']] == 'MP_REACH_NLRI':
+    
+                    """
+                    There is one exception to the encoding of BGP attributes for the BGP
+                    MP_REACH_NLRI attribute (BGP Type Code 14) [RFC4760].  Since the AFI,
+                    SAFI, and NLRI information is already encoded in the RIB Entry Header
+                    or RIB_GENERIC Entry Header, only the Next Hop Address Length and
+                    Next Hop Address fields are included.
+                    """
+    
+                    raw_next_hop_attr = buf[p:p+bgp_path_attribute['len']]
+    
+                    p += bgp_path_attribute['len']
+                    raw_mp_reach_nlri['value'] = self.crateMpReachNlriAttributeRaw(address_family, safi, raw_next_hop_attr, b"")
+    
+                # No parsing for other attributes.
+                else:
+                    p += bgp_path_attribute['len']
+                    raw_bgp_attributes.append(buf[start:end])
             else:
-                p += bgp_path_attribute['len']
-                raw_bgp_attributes.append(buf[start:end])
-
+                # Attribute not supported.
+                raise MrtFileException("Unsupported attribute type: {0}.".format(bgp_path_attribute['type'])
+ 
             bgp_attribute_list.append(bgp_path_attribute)
 
 


### PR DESCRIPTION
using this parser at yahoo we ran into some issues with the mrt parser when our bgp table dumps included attributes not supported by the parser. here's an update to warn on an unsupported type (this is what the openbmp collector does) but not to crash